### PR TITLE
Update hockey_env.py

### DIFF
--- a/laserhockey/hockey_env.py
+++ b/laserhockey/hockey_env.py
@@ -527,7 +527,7 @@ class HockeyEnv(gym.Env, EzPickle):
     # different proxy rewards:
     # Proxy reward/penalty for not being close to puck in the own half when puck is flying towards goal (not to opponent)
     reward_closeness_to_puck = 0
-    if self.puck.position[0] < CENTER_X and self.puck.linearVelocity[0] < 0:
+    if self.puck.position[0] < CENTER_X and self.puck.linearVelocity[0] <= 0:
       dist_to_puck = dist_positions(self.player1.position, self.puck.position)
       max_dist = 250. / SCALE
       max_reward = -30.  # max (negative) reward through this proxy


### PR DESCRIPTION
For the shooting training there will be no proxy reward until the agent does hit the puck. Therefore I think it would speed up training and would route the agent towards the puck if there would also be a negative reward if the puck does not move at all. I simply added a <= instead of a < to force this behavior.